### PR TITLE
fix(build): stabilize dokka v2 generation

### DIFF
--- a/.github/instructions/context.instructions.md
+++ b/.github/instructions/context.instructions.md
@@ -47,7 +47,7 @@ description: Use when understanding support-arch architecture, module boundaries
 
 ## Documentation Contract
 
-- Dokka is configured centrally in `buildSrc` and the root build script; CI publishes `./gradlew dokkaHtmlMultiModule` output from `dokka-docs` to the `docs` branch.
+- Dokka is configured centrally in `buildSrc` and the root build script; CI publishes `./gradlew dokkaGenerate` output from `dokka-docs` to the `docs` branch.
 - Dokka has `reportUndocumented = true`, so undocumented public APIs are a quality problem, not an optional cleanup task.
 - Packages matching `.internal` are intentionally suppressed from published docs. Do not hide consumer-facing APIs in internal packages.
 - When changing public behavior, update KDoc in the same change. Document what the API does, when to use it, and what a consumer must provide or expect.

--- a/.github/skills/support-arch-build-dependencies/references/build-map.md
+++ b/.github/skills/support-arch-build-dependencies/references/build-map.md
@@ -5,7 +5,7 @@ Use this map to choose the right build file before editing.
 | Concern | Primary files | Notes |
 | --- | --- | --- |
 | Module includes | `settings.gradle.kts` | Declares every published module in the repo |
-| Root repositories and multi-module Dokka output | `build.gradle.kts` | `dokkaHtmlMultiModule` writes to `dokka-docs` |
+| Root repositories and multi-module Dokka output | `build.gradle.kts` | Root `dokkaGenerate` writes the aggregate Dokka V2 site to `dokka-docs` |
 | Shared plugin entry point | `buildSrc/.../plugin/CorePlugin.kt` | Applies Android or Kotlin plugin, Dokka, publishing, Spotless, sources, dependencies |
 | Shared plugin application | `buildSrc/.../components/ProjectPlugins.kt` | Most modules use `co.anitrend.arch` |
 | Shared Android defaults | `buildSrc/.../components/AndroidConfiguration.kt` | SDK levels, view binding, tests, compiler options, toolchain 21 |

--- a/.github/workflows/gradle-dokka.yml
+++ b/.github/workflows/gradle-dokka.yml
@@ -10,6 +10,8 @@ env:
 jobs:
   gradle-dokka:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -23,10 +25,10 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Generate docs with dokka
-        run: ./gradlew dokkaGenerate
+        run: ./gradlew --no-daemon dokkaGenerate
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           branch: docs # The branch the action should deploy to.
-          folder: library/build/docs/dokka # The folder the action should deploy.
+          folder: dokka-docs # The root Dokka V2 publication output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 ## High-Signal Repo Facts
 
 - Public API docs are generated with Dokka and published to `https://anitrend.github.io/support-arch/`.
-- CI publishes docs by running `./gradlew dokkaHtmlMultiModule` on `develop` and deploying `dokka-docs` to the `docs` branch.
+- CI publishes docs by running `./gradlew dokkaGenerate` on `develop` and deploying `dokka-docs` to the `docs` branch.
 - Most modules use the shared `co.anitrend.arch` Gradle plugin from `buildSrc`.
 - Shared Android and Kotlin defaults live in `buildSrc`, not in individual module build files.
 - The pinned Java version is `.java-version = 21.0.8` and the shared toolchain is Java 21.
@@ -69,7 +69,7 @@
 ## Validation
 
 - Formatting: `./gradlew spotlessCheck` or `./gradlew spotlessApply`
-- Docs: `./gradlew dokkaHtmlMultiModule`
+- Docs: `./gradlew dokkaGenerate`
 - Tests: prefer targeted module tests before full-project runs
 - If Gradle or Java alignment is unstable, use the existing `jenv-gradle-low-ram` skill
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,30 @@ buildscript {
     }
     dependencies {
         classpath(libs.android.gradle.plugin)
+        classpath(libs.jetbrains.dokka.gradle)
         classpath(libs.jetbrains.kotlin.gradle)
     }
+}
+
+apply(plugin = "org.jetbrains.dokka")
+
+configure<org.jetbrains.dokka.gradle.DokkaExtension> {
+    moduleName.set("support-arch")
+    basePublicationsDirectory.set(layout.projectDirectory.dir("dokka-docs"))
+}
+
+dependencies {
+    add("dokka", project(":analytics"))
+    add("dokka", project(":core"))
+    add("dokka", project(":data"))
+    add("dokka", project(":domain"))
+    add("dokka", project(":extension"))
+    add("dokka", project(":paging-legacy"))
+    add("dokka", project(":recycler"))
+    add("dokka", project(":recycler-paging-legacy"))
+    add("dokka", project(":request"))
+    add("dokka", project(":theme"))
+    add("dokka", project(":ui"))
 }
 
 allprojects {

--- a/buildSrc/src/main/java/co/anitrend/arch/buildSrc/plugin/components/ProjectDokka.kt
+++ b/buildSrc/src/main/java/co/anitrend/arch/buildSrc/plugin/components/ProjectDokka.kt
@@ -59,6 +59,7 @@ private fun Project.dependenciesOfProject(): List<Modules.Module> {
 
 internal fun Project.configureDokka() = dokkaExtension().run {
     basePublicationsDirectory.set(layout.buildDirectory.dir("docs/dokka"))
+    val androidPublicationVariant = "release"
 
     // Set module name displayed in the final output
     moduleName.set(project.name)
@@ -74,7 +75,8 @@ internal fun Project.configureDokka() = dokkaExtension().run {
             //dependsOn(dependenciesOfProject().map(Modules.Module::path))
 
             // Used to remove a source set from documentation, test source sets are suppressed by default
-            suppress.set(false)
+            // Dokka V2 only supports one Android variant when debug/release share src/main roots.
+            suppress.set(!project.isKotlinLibraryGroup() && name != androidPublicationVariant)
 
             // Do not output deprecated members. Applies globally, can be overridden by packageOptions
             skipDeprecated.set(false)


### PR DESCRIPTION
# Pull Request Template

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/AniTrend/support-arch/blob/develop/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/AniTrend/support-arch/blob/develop/CONTRIBUTING.md)
- [x] Double-check your branch is based on `develop` and targets `develop` (where applicable)
- [x] Pull request has tests (If applicable)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved

## Description

Fix Dokka generation on `develop` after the Dokka V2 migration.

The failing CI task was `:analytics:dokkaGeneratePublicationHtml`. Dokka V2 cannot generate docs for Android modules when multiple enabled variants share the same `src/main` roots, and the current shared build logic was allowing both `debug` and `release` source sets through.

This patch:

- suppresses non-release Android Dokka variants in shared build logic
- configures root Dokka V2 aggregation to emit the published site to `dokka-docs`
- updates the docs workflow to deploy the correct output path and adds `contents: write`
- refreshes repo guidance that still referenced `dokkaHtmlMultiModule`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (Improve existing functionality)

## Verification

- `./gradlew --no-daemon --max-workers=2 -Dorg.gradle.jvmargs="-Xmx1536m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8" :buildSrc:compileKotlin`
- `./gradlew --no-daemon --max-workers=2 -Dorg.gradle.jvmargs="-Xmx1536m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8" :analytics:dokkaGeneratePublicationHtml`
- `./gradlew --no-daemon --max-workers=2 -Dorg.gradle.jvmargs="-Xmx1536m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8" dokkaGenerate`

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [Apache License](https://github.com/AniTrend/support-arch/blob/develop/LICENSE).
